### PR TITLE
Bumping poetry to 1.3.2 and uploading k8s test image to dockerhub

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo "INFERENCE_SERVICE_IMAGE_NAME=${{ secrets.DOCKER_HUB_USERNAME }}/spira-model-server:${{github.ref_name}}" >> $GITHUB_ENV
           echo "MLFLOW_SERVER_IMAGE_NAME=${{ secrets.DOCKER_HUB_USERNAME }}/spira-mlflow-server:${{github.ref_name}}" >> $GITHUB_ENV
-          echo "INFERENCE_SERVICE_TEST_IMAGE_NAME=${{ secrets.DOCKER_HUB_USERNAME }}/spira-mlflow-server-test:${{github.ref_name}}" >> $GITHUB_ENV
+          echo "INFERENCE_SERVICE_TEST_IMAGE_NAME=${{ secrets.DOCKER_HUB_USERNAME }}/spira-model-server-test:${{github.ref_name}}" >> $GITHUB_ENV
 
       - name: Push Image
         run: bash push-image.sh

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -30,6 +30,7 @@ jobs:
         run: |
           echo "INFERENCE_SERVICE_IMAGE_NAME=${{ secrets.DOCKER_HUB_USERNAME }}/spira-model-server:${{github.ref_name}}" >> $GITHUB_ENV
           echo "MLFLOW_SERVER_IMAGE_NAME=${{ secrets.DOCKER_HUB_USERNAME }}/spira-mlflow-server:${{github.ref_name}}" >> $GITHUB_ENV
+          echo "INFERENCE_SERVICE_TEST_IMAGE_NAME=${{ secrets.DOCKER_HUB_USERNAME }}/spira-mlflow-server-test:${{github.ref_name}}" >> $GITHUB_ENV
 
       - name: Push Image
         run: bash push-image.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8]
-        poetry-version: [1.1.13]
+        poetry-version: [1.3.2]
     runs-on: ubuntu-latest
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # --- base image --- #
 FROM python:3.8 as base
 
-ENV POETRY_VERSION=1.1.13
+ENV POETRY_VERSION=1.3.2
 
 RUN pip install "poetry==$POETRY_VERSION"
 RUN poetry config virtualenvs.create false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,17 @@ services:
     volumes:
       - "./src:/app/"
     
+  k8s-test-image:
+    build:
+      context: .
+      target: dev 
+    image: ${INFERENCE_SERVICE_IMAGE_NAME}
+    entrypoint: python3
+    volumes:
+      - ".:/app/"
+    ports:
+      - 3000:8000
+
   inference-tester:
     build:
       context: .

--- a/model_register_server/mlflow/.tool-versions
+++ b/model_register_server/mlflow/.tool-versions
@@ -1,2 +1,2 @@
 python 3.10.5
-poetry 1.1.13
+poetry 1.3.2

--- a/model_register_server/mlflow/Dockerfile
+++ b/model_register_server/mlflow/Dockerfile
@@ -1,7 +1,7 @@
 # --- base image --- #
 FROM python:3.8 as mlflow_base
 
-ENV POETRY_VERSION=1.1.13 
+ENV POETRY_VERSION=1.3.2 
 
 WORKDIR /project
 

--- a/model_register_server/mlflow/pyproject.toml
+++ b/model_register_server/mlflow/pyproject.toml
@@ -15,5 +15,5 @@ cryptography = "^37.0.4"
 [tool.poetry.dev-dependencies]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.3.2"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ black = "^22.10.0"
 black = {version = "^22.6.0", allow-prereleases = true}
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.3.2"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
### Motivation

Poetry was at an older version, which caused the build scripts to break due to a breaking change on urllib3.
Also, there was no image with the test files in dockerhub, which avoids us from running integration tests in k8s because. This PR adds the k8s image to the CD pipeline.